### PR TITLE
Adds the fix from PR #1, removes deprecated parameter, and updates install_requires

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,12 +1,12 @@
 from setuptools import setup, find_packages
 from pipenv.project import Project
-from pipenv.utils import convert_deps_to_pip
+from pipenv.utils.dependencies import convert_deps_to_pip
 from os import path
 from io import open
 
 here = path.abspath(path.dirname(__file__))
 pfile = Project(__file__).parsed_pipfile
-requirements = convert_deps_to_pip(pfile['packages'], r=False)
+requirements = convert_deps_to_pip(pfile['packages'])
 print(requirements)
 
 with open(path.join(here, 'README.md'), encoding='utf-8') as f:
@@ -40,7 +40,7 @@ setup(
     keywords='reverse_engineering android xamarin apk',
     packages=find_packages(),
     python_requires='>=3.5',
-    install_requires=requirements,
+    install_requires=requirements.values(),
     entry_points={
         'console_scripts': [
             'mono_unbundle=mono_unbundle.cli:cli'


### PR DESCRIPTION
This pull request includes the fix from PR #1 and also:

- Removes the deprecated `r` parameter from the `convert_deps_to_pip` function, as it was causing issues.
- Fixes the `install_requires` to correctly pull values from the dictionary, since the dictionary format wasn’t being accepted directly.